### PR TITLE
Update Pester requirement to v5.5

### DIFF
--- a/requirements.psd1
+++ b/requirements.psd1
@@ -3,7 +3,7 @@
         Target = 'CurrentUser'
     }
     'Pester' = @{
-        Version = '5.3.3'
+        Version = '5.5.0'
         Parameters = @{
             SkipPublisherCheck = $true
         }


### PR DESCRIPTION
GitHub Runner images are using Pester 5.5. This will make all the transient "Assembly with same name is already loaded" go away.
https://github.com/actions/runner-images/blob/main/images/win/Windows2019-Readme.md