### PR TITLE
v1 Rename logs to LogLines

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,13 +2,17 @@
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format
     "version": "2.0.0",
-
     // Start PowerShell (pwsh on *nix)
     "windows": {
         "options": {
             "shell": {
-                "executable": "powershell.exe",
-                "args": [ "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command" ]
+                "executable": "pwsh.exe",
+                "args": [
+                    "-NoProfile",
+                    "-ExecutionPolicy",
+                    "Bypass",
+                    "-Command"
+                ]
             }
         }
     },
@@ -16,7 +20,10 @@
         "options": {
             "shell": {
                 "executable": "/usr/bin/pwsh",
-                "args": [ "-NoProfile", "-Command" ]
+                "args": [
+                    "-NoProfile",
+                    "-Command"
+                ]
             }
         }
     },
@@ -24,11 +31,13 @@
         "options": {
             "shell": {
                 "executable": "/usr/local/bin/pwsh",
-                "args": [ "-NoProfile", "-Command" ]
+                "args": [
+                    "-NoProfile",
+                    "-Command"
+                ]
             }
         }
     },
-
     "tasks": [
         {
             "label": "Clean",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.0.0] logs to LogLines
+
+This version renames `logs` on the object to `LogLines`. For backwards
+compatibility `logs` is an alias to LogLines.
+
 ## [0.4.0] System.Collections.Generic.List[]
 
 Replace ArrayList to improve performance and be stricter about the expected
@@ -14,7 +19,8 @@ object.
 
 Adding formatters for both classes (`Log4NetLog` and `Log4NetLogLine`) so that
 it's easier to parse the objects. There is coloring using $PSStyle which means
-you need PS7 or to install the [PSStyle module](https://www.powershellgallery.com/packages/PSStyle).
+you need PS7 or to install the
+[PSStyle module](https://www.powershellgallery.com/packages/PSStyle).
 
 ## [0.2.0] Compiled
 

--- a/Log4NetParse/Classes/Log4NetLog.ps1
+++ b/Log4NetParse/Classes/Log4NetLog.ps1
@@ -1,18 +1,34 @@
 class Log4NetLog {
   [int]$Thread
-  [System.Collections.Generic.List[Log4NetLogLine]]$logs
-  [datetime]$startTime
-  [datetime]$endTime
-  [string]$filePath
+  [System.Collections.Generic.List[Log4NetLogLine]]$LogLines
+  [datetime]$StartTime
+  [datetime]$EndTime
+  [string]$FilePath
+
+  static [hashtable[]] $MemberDefinitions = @(
+    @{
+      MemberType = 'AliasProperty'
+      MemberName = 'logs'
+      Value = 'LogLines'
+    }
+  )
+
+  static Log4NetLog() {
+    $TypeName = [Log4NetLog].Name
+    foreach ($Definition in [Log4NetLog]::MemberDefinitions) {
+      Update-TypeData -TypeName $TypeName @Definition
+    }
+  }
 
   Log4NetLog(
     [int]$Thread,
-    [datetime]$startTime,
-    [string]$filePath
+    [datetime]$StartTime,
+    [string]$FilePath
   ) {
     $this.Thread = $Thread
-    $this.startTime = $startTime
-    $this.logs = [System.Collections.Generic.List[Log4NetLogLine]]::new()
-    $this.filePath = $filePath
+    $this.StartTime = $StartTime
+    $this.LogLines = [System.Collections.Generic.List[Log4NetLogLine]]::new()
+    $this.FilePath = $FilePath
   }
+
 }

--- a/Log4NetParse/Log4NetLog.format.ps1xml
+++ b/Log4NetParse/Log4NetLog.format.ps1xml
@@ -31,7 +31,7 @@
                 <PropertyName>thread</PropertyName>
               </TableColumnItem>
               <TableColumnItem>
-                <PropertyName>logs</PropertyName>
+                <PropertyName>LogLines</PropertyName>
               </TableColumnItem>
             </TableColumnItems>
             <Wrap/>

--- a/Log4NetParse/Log4NetParse.psd1
+++ b/Log4NetParse/Log4NetParse.psd1
@@ -12,7 +12,7 @@
   RootModule = 'Log4NetParse.psm1'
 
   # Version number of this module.
-  ModuleVersion = '0.4.0'
+  ModuleVersion = '1.0.0'
 
   # Supported PSEditions
   # CompatiblePSEditions = @()
@@ -24,7 +24,7 @@
   Author = 'Gilbert Sanchez'
 
   # Company or vendor of this module
-  CompanyName = 'Unknown'
+  CompanyName = 'Gilbert Sanchez'
 
   # Copyright statement for this module
   Copyright = '(c) Gilbert Sanchez. All rights reserved.'

--- a/Log4NetParse/Public/Read-Log4NetLog.ps1
+++ b/Log4NetParse/Public/Read-Log4NetLog.ps1
@@ -44,7 +44,8 @@ function Read-Log4NetLog {
   )
   $files = Get-Item -Path $Path
   if ($files.PSIsContainer) {
-    $files = Get-ChildItem -Path $Path -Filter $Filter | Sort-Object -Property LastWriteTime | Select-Object -Last $FileLimit
+    $files = Get-ChildItem -Path $Path -Filter $Filter |
+      Sort-Object -Property LastWriteTime | Select-Object -Last $FileLimit
   }
 
   [System.Collections.Generic.List[Log4NetLog]]$parsed = @()
@@ -63,7 +64,7 @@ function Read-Log4NetLog {
         # If it matches the regex, tag it
         if ( $m.Groups['thread'].Value -ne $currentSession.thread) {
           if ($currentSession) {
-            $currentSession.endTime = $currentSession.logs[-1].time
+            $currentSession.endTime = $currentSession.LogLines[-1].time
             $parsed.Add($currentSession) > $null
           }
 
@@ -75,7 +76,7 @@ function Read-Log4NetLog {
           )
         }
 
-        $currentSession.logs.Add(
+        $currentSession.LogLines.Add(
           [Log4NetLogLine]::new(
             [Datetime]($m.Groups['date'].Value -replace ',', '.'),
             $m.Groups['thread'].Value,
@@ -85,7 +86,7 @@ function Read-Log4NetLog {
       } else {
         # if it doesn't match regex, append to the previous
         if ($currentSession) {
-          $currentSession.logs[-1].AppendMessage($line)
+          $currentSession.LogLines[-1].AppendMessage($line)
         } else {
           # This might happen if the log starts on what should have been a
           # multiline entry... Not very likely

--- a/cspell.json
+++ b/cspell.json
@@ -1,0 +1,9 @@
+{
+    "version": "0.2",
+    "ignorePaths": [],
+    "dictionaryDefinitions": [],
+    "dictionaries": [],
+    "words": [],
+    "ignoreWords": [],
+    "import": []
+}

--- a/docs/en-US/Convert-PatternLayout.md
+++ b/docs/en-US/Convert-PatternLayout.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Convert-PatternLayout [[-PatternLayout] <String>] [<CommonParameters>]
+Convert-PatternLayout [[-PatternLayout] <String>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -40,6 +40,21 @@ Aliases:
 
 Required: False
 Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/requirements.psd1
+++ b/requirements.psd1
@@ -3,7 +3,7 @@
         Target = 'CurrentUser'
     }
     'Pester' = @{
-        Version = '5.5.0'
+        Version = '5.6.1'
         Parameters = @{
             SkipPublisherCheck = $true
         }

--- a/tests/Read-Log4NetLog.tests.ps1
+++ b/tests/Read-Log4NetLog.tests.ps1
@@ -71,9 +71,9 @@ Chocolatey upgraded 0/1 packages.
 "@
     }
 
-    $parsed = Read-Log4NetLog -Path $singleFile
-    $multiple = Read-Log4NetLog -Path $folder
-    $moreLimit = Read-Log4NetLog -Path $folder -FileLimit 10
+    $script:parsed = Read-Log4NetLog -Path $singleFile
+    $script:multiple = Read-Log4NetLog -Path $folder
+    $script:moreLimit = Read-Log4NetLog -Path $folder -FileLimit 10
   }
 
   Context 'For Single File' {
@@ -82,7 +82,7 @@ Chocolatey upgraded 0/1 packages.
     }
 
     It 'Parses the correct number of lines per session' {
-      $parsed[0].logs.Count | Should -Be 11
+      $parsed[0].LogLines.Count | Should -Be 11
     }
 
     It 'Detects the right session number' {


### PR DESCRIPTION
This version renames `logs` on the object to `LogLines`. For backwards
compatibility `logs` is an alias to LogLines.